### PR TITLE
◇クリコン微改変

### DIFF
--- a/header.html
+++ b/header.html
@@ -149,7 +149,14 @@ html,body {
   -moz-osx-font-smoothing: grayscale;
 }
 .imgintext{
-  filter: drop-shadow(0px 0px 10px rgba(231, 0, 29, 1)),drop-shadow(0px 0px 10px rgba(231, 0, 29, 1)),drop-shadow(0px 0px 10px rgba(231, 0, 29, 0.2));}
+  filter: drop-shadow(0px 0px 10px rgba(231, 0, 29, 1)),drop-shadow(0px 0px 10px rgba(231, 0, 29, 1)),drop-shadow(0px 0px 10px rgba(231, 0, 29, 0.2));
+}
+.faintshadow {
+  -moz-text-shadow: 0px 0px 10px rgba(231, 0, 29, 0.8),0px 0px 10px rgba(231, 0, 29, 0.6),0px 0px 10px rgba(231, 0, 29, 0.2);
+  -webkit-text-shadow: 0px 0px 10px rgba(231, 0, 29, 0.8),0px 0px 10px rgba(231, 0, 29, 0.6),0px 0px 10px rgba(231, 0, 29, 0.2);
+  -ms-text-shadow: 0px 0px 10px rgba(231, 0, 29, 0.8),0px 0px 10px rgba(231, 0, 29, 0.6),0px 0px 10px rgba(231, 0, 29, 0.2);
+  text-shadow: 0px 0px 10px rgba(231, 0, 29, 0.8),0px 0px 10px rgba(231, 0, 29, 0.6),0px 0px 10px rgba(231, 0, 29, 0.2);
+}
 body{
   background-color: #eddda6;
   overflow: hidden;
@@ -287,6 +294,12 @@ footer.page-footer{
 emphasis{
   -webkit-text-emphasis: dot;
   text-emphasis: dot;
+}
+.centering{
+  text-align: center;
+}
+small {
+  font-size: 0.7em;
 }
   </style>
 <!--[if gte IE 9]

--- a/index.1.html
+++ b/index.1.html
@@ -189,11 +189,11 @@ function startShowing(){
 
 <div class="bg-xmas">
 <div class="section container" style="color:#fff;">
-<p>【行事のお知らせ】</p>
-<div style="display:block;font-size:3.56rem;">
+<p class="centering">【行事のお知らせ】</p>
+<div style="display:block;font-size:3.56rem;" class="centering">
 <i class="icon-ths-Otokogumi"></i><i class="icon-ths-two"></i><i class="icon-ths-chorus"></i><i class="icon-ths-tmo"></i><br><h2 style="font-weight:900;display:inline;">THS Christmas Concert</h2></div>
-<p style="font-weight:700;font-size:1.5em;margin-bottom:1em;">&ensp;&ensp;とき：2016年12月23日(金･天皇誕生日)<br>&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;14時開演<br>ところ：群馬県立高崎高校 翠巒会館<br>入場料：無料</p>
-<p>音楽系部活動4部合同クリスマスコンサートです。<br>高崎高校へ行けば、翠巒会館へ係員がご案内します。<br>高崎駅西口4番のりば 13:20発のぐるりんバスがお薦めです。料金片道200円。<br><b>高崎高校は、高チャリ範囲外です。高チャリを使って和田橋を渡らないでください。</b></p><h3 style="font-size:1.8rem;font-weight:500;">演奏順</h3><ol><li>マンドリン部</li><li>合唱部</li><li>吹奏楽部</li><li>和太鼓部</li></ol>
+<p class="faintshadow" style="font-weight:700;font-size:1.5em;margin-bottom:1em;">&ensp;&ensp;とき：<small>2016年</small>12月23日<small>(金･天皇誕生日)</small><br>&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;14時開演<br>ところ：高崎高校 翠巒会館<br>入場料：無料</p>
+<p class="faintshadow">音楽系部活動4部合同クリスマスコンサートです。<br>高崎高校へ行けば、翠巒会館へ係員がご案内します。<br>高崎駅西口4番のりば 13:20発のぐるりんバスがお薦めです。料金片道200円。<br><b>高崎高校は、高チャリ範囲外です。高チャリを使って和田橋を渡らないでください。</b></p><h3 style="font-size:1.8rem;font-weight:500;">演奏順</h3><ol class="faintshadow"><li>マンドリン部</li><li>合唱部</li><li>吹奏楽部</li><li>和太鼓部</li></ol>
 </div>
 </div>
 <div id="kyosan_banners"></div>

--- a/index.html
+++ b/index.html
@@ -188,11 +188,11 @@ function startShowing(){
 
 <div class="bg-xmas">
 <div class="section container" style="color:#fff;">
-<p>【行事のお知らせ】</p>
-<div style="display:block;font-size:3.56rem;">
+<p class="centering">【行事のお知らせ】</p>
+<div style="display:block;font-size:3.56rem;" class="centering">
 <i class="icon-ths-Otokogumi"></i><i class="icon-ths-two"></i><i class="icon-ths-chorus"></i><i class="icon-ths-tmo"></i><br><h2 style="font-weight:900;display:inline;">THS Christmas Concert</h2></div>
-<p style="font-weight:700;font-size:1.5em;margin-bottom:1em;">&ensp;&ensp;とき：2016年12月23日(金･天皇誕生日)<br>&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;14時開演<br>ところ：群馬県立高崎高校 翠巒会館<br>入場料：無料</p>
-<p>音楽系部活動4部合同クリスマスコンサートです。<br>高崎高校へ行けば、翠巒会館へ係員がご案内します。<br>高崎駅西口4番のりば 13:20発のぐるりんバスがお薦めです。料金片道200円。<br><b>高崎高校は、高チャリ範囲外です。高チャリを使って和田橋を渡らないでください。</b></p><h3 style="font-size:1.8rem;font-weight:500;">演奏順</h3><ol><li>マンドリン部</li><li>合唱部</li><li>吹奏楽部</li><li>和太鼓部</li></ol>
+<p class="faintshadow" style="font-weight:700;font-size:1.5em;margin-bottom:1em;">&ensp;&ensp;とき：<small>2016年</small>12月23日<small>(金･天皇誕生日)</small><br>&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;14時開演<br>ところ：高崎高校 翠巒会館<br>入場料：無料</p>
+<p class="faintshadow">音楽系部活動4部合同クリスマスコンサートです。<br>高崎高校へ行けば、翠巒会館へ係員がご案内します。<br>高崎駅西口4番のりば 13:20発のぐるりんバスがお薦めです。料金片道200円。<br><b>高崎高校は、高チャリ範囲外です。高チャリを使って和田橋を渡らないでください。</b></p><h3 style="font-size:1.8rem;font-weight:500;">演奏順</h3><ol class="faintshadow"><li>マンドリン部</li><li>合唱部</li><li>吹奏楽部</li><li>和太鼓部</li></ol>
 </div>
 </div>
 


### PR DESCRIPTION
見出しをtext-align:centerに
　→僕の好み

とき」の”2016年””金・天皇誕生日”をちっちゃく（画像では.7em）
　→スマホなど横幅狭いデバイスで見たとき変な改行されにくくなる
　　相対的に12月23日が目立つ

縦の余白広げた（とりあえず32px統一）
　→ちょっとすっきりして見える

見出しと本文でtext-shadowの濃さに差をつけ
（本文のalphaを0.8,0.6,0.2に変更）
　→メリハリがつくはず